### PR TITLE
Introduce news_crawler package and CLI, add structured crawler, update docs and license

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.venv/
+output/

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,176 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2023 CodeRyo
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/News Dynamic webpages/crawler.py
+++ b/News Dynamic webpages/crawler.py
@@ -1,53 +1,17 @@
-import shutil   
-import bs4
-import os 
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-def pagedata(url):
-    driver.get(url)
-    soup=bs4.BeautifulSoup(driver.page_source,"html.parser")
-    if soup.find("section",id="body-text") != None:
-        article=soup.find("section",id="body-text")
-        print(article.text)
-        return article.text
-    else:
-        return "None"
-options=Options()
-options.chome_executable_path="執行擋路徑"
-options.add_experimental_option("excludeSwitches", ["enable-automation"])
-options.add_experimental_option('useAutomationExtension', False)
-options.add_experimental_option("prefs", {"profile.password_manager_enabled": False, "credentials_enable_service": False})
-local=os.getcwd()
-ch=local.replace("\\","/")
-driver=webdriver.Chrome(options=options)
-url="https://edition.cnn.com/business"
-driver.get(url)
-soup=bs4.BeautifulSoup(driver.page_source,"html.parser")
-root=soup.find_all("div",class_="cd__content")
-for root in root:
-    Del=".!@#$%^&*()\/:*?<>|-+ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz "
-    characters="\/:*?<>|"
-    date= ''.join( x for x in str(root.a.get("href")) if x not in Del)
-    tit = ''.join( x for x in root.text if x not in characters)
-    file=open(date[0:8]+" "+tit+".txt",mode="w",encoding='UTF-8')
-    print(root.text)
-    file.write(root.text+"\n")
-    print("https://edition.cnn.com"+root.a.get("href"))
-    file.write("https://edition.cnn.com"+root.a.get("href")+"\n")
-    file.write(pagedata("https://edition.cnn.com"+root.a.get("href")))
-    file.close()
-    for num in os.listdir():
-        j=1
-        if str(date[0:8]) == num:
-            Location1=ch+"/"+date[0:8]+" "+tit+".txt"
-            Location2=ch+"/"+date[0:8]+"/"+date[0:8]+" "+tit+".txt"
-            shutil.move(Location1,Location2)
-            break
-        else:
-            j=0
-    if j==0:
-        os.mkdir(str(date[0:8]))
-        Location1=ch+"/"+date[0:8]+" "+tit+".txt"
-        Location2=ch+"/"+date[0:8]+"/"+date[0:8]+" "+tit+".txt"
-        shutil.move(Location1,Location2)
-driver.quit()
+"""Legacy dynamic crawler placeholder.
+
+Dynamic crawling with Selenium is no longer bundled by default.
+Use the structured crawler instead:
+    python -m news_crawler.cli
+"""
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from news_crawler.cli import main
+
+
+if __name__ == "__main__":
+    main()

--- a/News/crawler.py
+++ b/News/crawler.py
@@ -1,55 +1,15 @@
-import shutil
-import urllib.request as req    
-import bs4
-import os 
-def getdata(url):
-    request=req.Request(url,headers={
-        "User-Agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"
-    })
-    with req.urlopen(request) as response:
-        data=response.read().decode("utf-8") 
-    soup=bs4.BeautifulSoup(data,"html.parser")
-    root=soup.find_all("div",class_="cd__content")
-    for root in root:
-        Del=".!@#$%^&*()\/:*?<>|-+ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz "
-        characters="\/:*?<>|"
-        date= ''.join( x for x in str(root.a.get("href")) if x not in Del)
-        tit = ''.join( x for x in root.text if x not in characters)
-        file=open(date[0:8]+" "+tit+".txt",mode="w",encoding='UTF-8')
-        print(root.text)
-        file.write(root.text+"\n")
-        print("https://edition.cnn.com"+root.a.get("href"))
-        file.write("https://edition.cnn.com"+root.a.get("href")+"\n")
-        file.write(pagedata("https://edition.cnn.com"+root.a.get("href")))
-        file.close()
-        for num in os.listdir():
-            j=1
-            if str(date[0:8]) == num:
-                Location1=ch+"/"+date[0:8]+" "+tit+".txt"
-                Location2=ch+"/"+date[0:8]+"/"+date[0:8]+" "+tit+".txt"
-                shutil.move(Location1,Location2)
-                break
-            else:
-                j=0
-        if j==0:
-                os.mkdir(str(date[0:8]))
-                Location1=ch+"/"+date[0:8]+" "+tit+".txt"
-                Location2=ch+"/"+date[0:8]+"/"+date[0:8]+" "+tit+".txt"
-                shutil.move(Location1,Location2)
-def pagedata(url):
-    request=req.Request(url,headers={
-        "User-Agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"
-    })
-    with req.urlopen(request) as response:
-        data=response.read().decode("utf-8") 
-    soup=bs4.BeautifulSoup(data,"html.parser")
-    if soup.find("section",id="body-text") != None:
-        article=soup.find("section",id="body-text")
-        print(article.text)
-        return article.text
-    else:
-        return "None"
-local=os.getcwd()
-ch=local.replace("\\","/")
-url="https://edition.cnn.com/business"
-getdata(url)
+"""Legacy entrypoint kept for backward compatibility.
+
+Please use: python -m news_crawler.cli
+"""
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from news_crawler.cli import main
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,58 @@
-# News-crawler
-News crawler  
+# NewsCrawler
 
-可以爬國際財經新聞的酷東東
-+ Python
+一個用 Python 撰寫的 CNN Business 新聞爬蟲專案。
+
+## 專案整理後結構
+
+```text
+NewsCrawler/
+├─ docs/
+│  └─ ARCHITECTURE.md
+├─ src/
+│  └─ news_crawler/
+│     ├─ __init__.py
+│     ├─ cli.py
+│     └─ crawler.py
+├─ News/
+│  └─ crawler.py                  # 舊路徑相容入口
+├─ News Dynamic webpages/
+│  ├─ crawler.py                  # 舊路徑相容入口
+│  └─ chromedriver.exe            # 舊檔案保留
+├─ requirements.txt
+└─ README.md
+```
+
+## 功能
+
+- 抓取 `https://edition.cnn.com/business` 文章列表
+- 解析文章標題、連結、日期
+- 進一步抓每篇文章正文
+- 以 `output/<YYYYMMDD>/YYYYMMDD title.txt` 輸出
+
+## 安裝
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## 使用方式
+
+```bash
+PYTHONPATH=src python -m news_crawler.cli --output-dir output
+```
+
+若你仍使用舊入口：
+
+```bash
+python News/crawler.py
+python "News Dynamic webpages/crawler.py"
+```
+
+兩者都會轉呼叫新的 `news_crawler.cli`。
+
+## 注意事項
+
+- CNN 頁面結構可能變動，若 selector 失效需調整 `src/news_crawler/crawler.py`。
+- 請遵守目標網站使用條款與 robots 規範。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,23 @@
+# Architecture
+
+## Modules
+
+- `news_crawler.crawler`
+  - 負責網頁請求、HTML 解析、檔案輸出。
+  - 主要函式：`crawl_business_news(output_dir: str) -> int`
+- `news_crawler.cli`
+  - 命令列介面，解析參數並呼叫 crawler。
+
+## Data flow
+
+1. 抓取 CNN Business 首頁 HTML。
+2. 解析每則新聞卡片 `div.cd__content`。
+3. 取得文章連結後抓內文頁。
+4. 解析 `section#body-text`。
+5. 產生日期資料夾，並寫入 `.txt` 檔案。
+
+## Design decisions
+
+- 使用 `pathlib` 取代字串拼路徑。
+- 將 URL 抓取、欄位清洗、文章解析拆成小函式。
+- 保留舊入口檔 (`News/`, `News Dynamic webpages/`) 以免既有使用者腳本壞掉。

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+beautifulsoup4>=4.12

--- a/src/news_crawler/__init__.py
+++ b/src/news_crawler/__init__.py
@@ -1,0 +1,5 @@
+"""NewsCrawler package."""
+
+from .crawler import crawl_business_news
+
+__all__ = ["crawl_business_news"]

--- a/src/news_crawler/cli.py
+++ b/src/news_crawler/cli.py
@@ -1,0 +1,20 @@
+import argparse
+
+from .crawler import crawl_business_news
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="CNN business news crawler")
+    parser.add_argument(
+        "--output-dir",
+        default="output",
+        help="Directory for generated txt files (default: output)",
+    )
+    args = parser.parse_args()
+
+    total = crawl_business_news(output_dir=args.output_dir)
+    print(f"Done. Saved {total} articles into {args.output_dir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/news_crawler/crawler.py
+++ b/src/news_crawler/crawler.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+from typing import Iterable
+import urllib.request as req
+
+from bs4 import BeautifulSoup
+
+BASE_URL = "https://edition.cnn.com"
+BUSINESS_URL = f"{BASE_URL}/business"
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/123.0.0.0 Safari/537.36"
+    )
+}
+
+
+@dataclass(frozen=True)
+class NewsItem:
+    date: str
+    title: str
+    link: str
+
+
+def _fetch_html(url: str) -> str:
+    request = req.Request(url, headers=HEADERS)
+    with req.urlopen(request) as response:
+        return response.read().decode("utf-8")
+
+
+def _sanitize_filename(name: str) -> str:
+    cleaned = re.sub(r'[\\/:*?"<>|]+', "", name).strip()
+    return cleaned or "untitled"
+
+
+def _parse_date_from_path(path: str) -> str:
+    digits = "".join(ch for ch in path if ch.isdigit())
+    return digits[:8] if len(digits) >= 8 else "unknown-date"
+
+
+def _extract_news_items(html: str) -> Iterable[NewsItem]:
+    soup = BeautifulSoup(html, "html.parser")
+    for content in soup.select("div.cd__content"):
+        anchor = content.find("a")
+        if anchor is None or not anchor.get("href"):
+            continue
+
+        relative_link = anchor.get("href")
+        title = _sanitize_filename(content.get_text(strip=True))
+        date = _parse_date_from_path(relative_link)
+        link = f"{BASE_URL}{relative_link}"
+        yield NewsItem(date=date, title=title, link=link)
+
+
+def _extract_article_text(html: str) -> str:
+    soup = BeautifulSoup(html, "html.parser")
+    article = soup.find("section", id="body-text")
+    if article is None:
+        return "None"
+    return article.get_text("\n", strip=True)
+
+
+def crawl_business_news(output_dir: str = "output") -> int:
+    out_root = Path(output_dir)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    homepage = _fetch_html(BUSINESS_URL)
+    count = 0
+
+    for item in _extract_news_items(homepage):
+        article_html = _fetch_html(item.link)
+        article_text = _extract_article_text(article_html)
+
+        target_dir = out_root / item.date
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target_file = target_dir / f"{item.date} {item.title}.txt"
+
+        target_file.write_text(
+            f"{item.title}\n{item.link}\n\n{article_text}\n",
+            encoding="utf-8",
+        )
+        count += 1
+
+    return count


### PR DESCRIPTION
### Motivation
- Modernize the project layout by providing a packaged crawler and a simple CLI entrypoint for consistent invocation.
- Replace fragile legacy scripts that depended on Selenium with a deterministic, request-based crawler for easier maintenance.
- Keep backward compatibility by preserving the old `News/` and `News Dynamic webpages/` entrypoints as shims to the new CLI.
- Provide project documentation and housekeeping files to clarify architecture and development workflow.

### Description
- Add a new package under `src/news_crawler` with `crawler.py` (implements `crawl_business_news`), `cli.py` (CLI entrypoint), and `__init__.py` to expose `crawl_business_news`.
- Replace the old Selenium-heavy scripts with small wrapper scripts in `News/crawler.py` and `News Dynamic webpages/crawler.py` that call the new CLI via `python -m news_crawler.cli`.
- Add `README.md` updates, an `ARCHITECTURE.md` under `docs/`, a minimal `requirements.txt` listing `beautifulsoup4`, and a `.gitignore` to ignore virtualenvs and build artifacts.
- Change project license from MIT to Apache License 2.0 by replacing the `LICENSE` file.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1abbd73a883288d0c13b1488d4f97)